### PR TITLE
fix: dodanie CSRF_TRUSTED_ORIGINS #42

### DIFF
--- a/navigation/settings.py
+++ b/navigation/settings.py
@@ -42,6 +42,10 @@ ALLOWED_HOSTS = [
     '169.254.129.14'
 ]
 
+CSRF_TRUSTED_ORIGINS = [
+    'https://sggw-nawigacja-dev-app-api.azurewebsites.net'
+]
+
 
 # Application definition
 


### PR DESCRIPTION
Dodanie adresu zewnętrznego hosta do CSRF_TRUSTED_ORIGINS w settings.py.